### PR TITLE
Adds Cocoapod support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
+gem 'cocoapods', '~>0.37.2'
 gem 'xcpretty'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,57 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (4.2.3)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    claide (0.8.2)
+    cocoapods (0.37.2)
+      activesupport (>= 3.2.15)
+      claide (~> 0.8.1)
+      cocoapods-core (= 0.37.2)
+      cocoapods-downloader (~> 0.9.0)
+      cocoapods-plugins (~> 0.4.2)
+      cocoapods-trunk (~> 0.6.1)
+      cocoapods-try (~> 0.4.5)
+      colored (~> 1.2)
+      escape (~> 0.0.4)
+      molinillo (~> 0.2.3)
+      nap (~> 0.8)
+      xcodeproj (~> 0.24.2)
+    cocoapods-core (0.37.2)
+      activesupport (>= 3.2.15)
+      fuzzy_match (~> 2.0.4)
+      nap (~> 0.8.0)
+    cocoapods-downloader (0.9.1)
+    cocoapods-plugins (0.4.2)
+      nap
+    cocoapods-trunk (0.6.1)
+      nap (>= 0.8)
+      netrc (= 0.7.8)
+    cocoapods-try (0.4.5)
+    colored (1.2)
+    escape (0.0.4)
+    fuzzy_match (2.0.4)
+    i18n (0.7.0)
+    json (1.8.3)
+    minitest (5.7.0)
+    molinillo (0.2.3)
+    nap (0.8.0)
+    netrc (0.7.8)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    xcodeproj (0.24.3)
+      activesupport (>= 3)
+      colored (~> 1.2)
     xcpretty (0.1.10)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  cocoapods (~> 0.37.2)
   xcpretty

--- a/README.md
+++ b/README.md
@@ -31,6 +31,24 @@ project.
 [Result]: https://github.com/antitypical/Result
 [ReactiveCocoa]: https://github.com/ReactiveCocoa/ReactiveCocoa
 
+### [CocoaPods]
+
+[CocoaPods]: http://cocoapods.org
+
+Add the following to your [Podfile](http://guides.cocoapods.org/using/the-podfile.html):
+
+```ruby
+pod 'ReactiveArray'
+```
+
+You will also need to make sure you're opting into using frameworks:
+
+```ruby
+use_frameworks!
+```
+
+Then run `pod install` with CocoaPods 0.36 or newer.
+
 ## Usage
 
 TODO

--- a/ReactiveArray.podspec
+++ b/ReactiveArray.podspec
@@ -1,0 +1,20 @@
+Pod::Spec.new do |spec|
+  spec.name = 'ReactiveArray'
+  spec.version = '0.1.0'
+  spec.summary = "An array class implemented in Swift that can be observed using ReactiveCocoa's Signals."
+  spec.homepage = 'https://github.com/Wolox/ReactiveArray'
+  spec.license = { :type => 'MIT', :file => 'LICENSE' }
+  spec.author = {
+    'Guido Marucci Blas' => 'guidomb@wolox.com.ar',
+    'Wolox' => nil,
+  }
+  spec.social_media_url = 'http://twitter.com/wolox'
+  spec.source = { :git => 'https://github.com/Wolox/ReactiveArray.git', :tag => "v#{spec.version}" }
+  spec.source_files = 'ReactiveArray/**/*.{h,swift}'
+  spec.requires_arc = true
+  spec.ios.deployment_target = '8.0'
+  spec.osx.deployment_target = '10.9'
+
+  spec.dependency 'ReactiveCocoa', '3.0-beta.6'
+  spec.framework = "Foundation"
+end


### PR DESCRIPTION
This is a work-in-progress and needs to be fixed because `bundle exec pod lib lint` exits with error.

```
 -> ReactiveArray (0.1.0)
    - ERROR | [OSX] Returned an unsuccessful exit code. You can use `--verbose` for more information.
    - ERROR |  /Users/guidomb/Documents/projects/wolox/ReactiveArray/ReactiveArray/ReactiveArray.swift:20:8: error: no such module 'ReactiveCocoa'

[!] ReactiveArray did not pass validation.
You can use the `--no-clean` option to inspect any issue.
```