### PR TITLE
Add a convenience initializer that takes a variadic list of elements

### DIFF
--- a/ReactiveArray/ReactiveArray.swift
+++ b/ReactiveArray/ReactiveArray.swift
@@ -98,6 +98,10 @@ public final class ReactiveArray<T>: CollectionType, MutableCollectionType, Debu
         self.init(elements: [])
     }
     
+	public convenience init(_ elements: T...) {
+		self.init(elements: elements)
+	}
+	
     public subscript(index: Int) -> T {
         get {
             return _elements[index]


### PR DESCRIPTION
Resolves #8 . Unfortunately the compiler can't infer the element type in this case so you have to do `ReactiveArray<Int>(1, 2, 3, 4)`. I'd actually say _not_ to merge this, since manually specifying the type is dumb, but I felt like getting my feet wet with those awesome-looking project! 