### PR TITLE
Add .Update operation and fix .Insert operation

### DIFF
--- a/ReactiveArray/Info.plist
+++ b/ReactiveArray/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.0</string>
+	<string>0.4.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/ReactiveArray/Operation.swift
+++ b/ReactiveArray/Operation.swift
@@ -12,6 +12,7 @@ public enum Operation<T>: CustomDebugStringConvertible {
     
     case Append(value: T)
     case Insert(value: T, atIndex: Int)
+    case Update(value: T, atIndex: Int)
     case RemoveElement(atIndex: Int)
     
     public func map<U>(mapper: T -> U) -> Operation<U> {
@@ -21,6 +22,8 @@ public enum Operation<T>: CustomDebugStringConvertible {
             result = Operation<U>.Append(value: mapper(value))
         case .Insert(let value, let index):
             result = Operation<U>.Insert(value: mapper(value), atIndex: index)
+        case .Update(let value, let index):
+            result = Operation<U>.Update(value: mapper(value), atIndex: index)
         case .RemoveElement(let index):
             result = Operation<U>.RemoveElement(atIndex: index)
         }
@@ -34,6 +37,8 @@ public enum Operation<T>: CustomDebugStringConvertible {
             description = ".Append(value:\(value))"
         case .Insert(let value, let index):
             description = ".Insert(value: \(value), atIndex:\(index))"
+        case .Update(let value, let index):
+            description = ".Update(value: \(value), atIndex:\(index))"
         case .RemoveElement(let index):
             description = ".RemoveElement(atIndex:\(index))"
         }
@@ -45,6 +50,8 @@ public enum Operation<T>: CustomDebugStringConvertible {
         case .Append(let value):
             return value
         case .Insert(let value, _):
+            return value
+        case .Update(let value, _):
             return value
         default:
             return Optional.None
@@ -58,6 +65,8 @@ public func ==<T: Equatable>(lhs: Operation<T>, rhs: Operation<T>) -> Bool {
     case (.Append(let leftValue), .Append(let rightValue)):
         return leftValue == rightValue
     case (.Insert(let leftValue, let leftIndex), .Insert(let rightValue, let rightIndex)):
+        return leftIndex == rightIndex && leftValue == rightValue
+    case (.Update(let leftValue, let leftIndex), .Update(let rightValue, let rightIndex)):
         return leftIndex == rightIndex && leftValue == rightValue
     case (.RemoveElement(let leftIndex), .RemoveElement(let rightIndex)):
         return leftIndex == rightIndex

--- a/ReactiveArray/ReactiveArray.swift
+++ b/ReactiveArray/ReactiveArray.swift
@@ -103,7 +103,7 @@ public final class ReactiveArray<T>: CollectionType, MutableCollectionType, Cust
             return _elements[index]
         }
         set(newValue) {
-            insert(newValue, atIndex: index)
+            update(newValue, atIndex: index)
         }
     }
     
@@ -114,6 +114,11 @@ public final class ReactiveArray<T>: CollectionType, MutableCollectionType, Cust
     
     public func insert(newElement: T, atIndex index : Int) {
         let operation: Operation<T> = .Insert(value: newElement, atIndex: index)
+        _sink(Event.Next(operation))
+    }
+    
+    public func update(element: T, atIndex index: Int) {
+        let operation: Operation<T> = .Update(value: element, atIndex: index)
         _sink(Event.Next(operation))
     }
     
@@ -136,6 +141,8 @@ public final class ReactiveArray<T>: CollectionType, MutableCollectionType, Cust
             _elements.append(value)
             _mutableCount.value = _elements.count
         case .Insert(let value, let index):
+            _elements.insert(value, atIndex: index)
+        case .Update(let value, let index):
             _elements[index] = value
         case .RemoveElement(let index):
             _elements.removeAtIndex(index)

--- a/ReactiveArrayTests/OperationSpec.swift
+++ b/ReactiveArrayTests/OperationSpec.swift
@@ -49,6 +49,21 @@ class OperationSpec: QuickSpec {
                 
             }
             
+            context("when the operation is an Update operation") {
+                
+                beforeEach {
+                    operation = Operation.Update(value: 10, atIndex: 5)
+                }
+                
+                it("maps the value to be updated") {
+                    let mappedOperation = operation.map { $0 * 2 }
+                    
+                    let areEqual = mappedOperation == Operation.Update(value: 20, atIndex: 5)
+                    expect(areEqual).to(beTrue())
+                }
+                
+            }
+            
             context("when the operation is a Delete operation") {
                 
                 beforeEach {
@@ -87,6 +102,18 @@ class OperationSpec: QuickSpec {
                 }
                 
                 it("returns the inserted value") {
+                    expect(operation.value).to(equal(10))
+                }
+                
+            }
+            
+            context("when the operation is an Update operation") {
+                
+                beforeEach {
+                    operation = Operation.Update(value: 10, atIndex: 5)
+                }
+                
+                it("returns the updated value") {
                     expect(operation.value).to(equal(10))
                 }
                 


### PR DESCRIPTION
`.Update` operation allows for Array's subscripting to work as expected. `.Insert` is fixed to work as Array's `insert:atIndex`.