### PR TITLE
Fix observable count bug on insert

### DIFF
--- a/ReactiveArray/ReactiveArray.swift
+++ b/ReactiveArray/ReactiveArray.swift
@@ -142,6 +142,7 @@ public final class ReactiveArray<T>: CollectionType, MutableCollectionType, Cust
             _mutableCount.value = _elements.count
         case .Insert(let value, let index):
             _elements.insert(value, atIndex: index)
+            _mutableCount.value = _elements.count
         case .Update(let value, let index):
             _elements[index] = value
         case .RemoveElement(let index):

--- a/ReactiveArrayTests/ReactiveArraySpec.swift
+++ b/ReactiveArrayTests/ReactiveArraySpec.swift
@@ -429,7 +429,7 @@ class ReactiveArraySpec: QuickSpec {
                     producer = producer.skip(1)
                 }
                 
-                it("does not update the count") {
+                it("updates the count") {
                     waitUntil { done in
                         producer
                             .take(1)
@@ -452,7 +452,7 @@ class ReactiveArraySpec: QuickSpec {
                     producer = producer.skip(1)
                 }
                 
-                it("updates the count") {
+                it("does not update the count") {
                     waitUntil { done in
                         array[1] = 656
                         expect(array.count).to(equal(countBeforeOperation))

--- a/ReactiveArrayTests/ReactiveArraySpec.swift
+++ b/ReactiveArrayTests/ReactiveArraySpec.swift
@@ -432,10 +432,10 @@ class ReactiveArraySpec: QuickSpec {
                 it("updates the count") {
                     waitUntil { done in
                         producer
-                            .take(1)
+                            .take(2)
                             .collect()
                             .startWithNext { counts in
-                                expect(counts).to(equal([countBeforeOperation + 2]))
+                                expect(counts).to(equal([countBeforeOperation + 1, countBeforeOperation + 2]))
                                 done()
                             }
                         


### PR DESCRIPTION
This fixes a bug that causes a `ReactiveArray` instance to not send observable count events when a new element is inserted into it. Got confused at first since the unit test cases seemed to agree with the code. I've updated the unit test as well to reflect the fix.