### PR TITLE
dispose of producer in deinit

### DIFF
--- a/ReactiveArray/ReactiveArray.swift
+++ b/ReactiveArray/ReactiveArray.swift
@@ -89,10 +89,15 @@ public final class ReactiveArray<T>: CollectionType, MutableCollectionType, Cust
 
     }
     
+    var disposeBag : [Disposable] = []
     public convenience init(producer: OperationProducer) {
         self.init()
         
-        producer.start(_sink)
+        disposeBag += [producer.start(_sink)]
+    }
+    
+    deinit {
+        for d in disposeBag { d.dispose() }
     }
     
     public convenience init() {


### PR DESCRIPTION
This fixes a crash where if the ReactiveArray was initialized with a producer and the producer sends a value after the ReactiveArray has been dealloced, the app will crash on calling a method on unowned dealloced self in _signal.observe.

Easiest way to reproduce this bug is using a mirror:
```
let xs = ReactiveArray<String>()
;{
let ys = xs.mirror { _ in "I will crash" }
}()
xs.append("ys shall crash now!")
```

There may be better ways to fix this than my solution, so feel free to implement your own.
I would have liked to use `.takeUntil(willDeallocSignal)` instead of the disposeBag, but I dont have a `willDeallocSignal` for arbitrary swift classes (not NSObject)
I could tackle this by disposing of the _signal.observe to prevent other possible problems of this kind, but I felt like my change fixes this particular problem as locally as possible.
