### PR TITLE
Update ReactiveCocoa to 4.1.0 & fix xcodeproj settings

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactiveCocoa/ReactiveCocoa" "v4.0.0-alpha.5"
+github "ReactiveCocoa/ReactiveCocoa" "v4.1.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "Quick/Nimble" "v3.0.0"
+github "Quick/Nimble" "v3.2.0"
 github "Quick/Quick" "v0.8.0"
-github "antitypical/Result" "1.0.1"
-github "ReactiveCocoa/ReactiveCocoa" "v4.0.0-alpha.5"
+github "antitypical/Result" "2.0.0"
+github "ReactiveCocoa/ReactiveCocoa" "v4.1.0"

--- a/ReactiveArray.xcodeproj/project.pbxproj
+++ b/ReactiveArray.xcodeproj/project.pbxproj
@@ -162,7 +162,6 @@
 				9DF1E5361B41E438007A6182 /* Frameworks */,
 				9DF1E5371B41E438007A6182 /* Headers */,
 				9DF1E5381B41E438007A6182 /* Resources */,
-				9DF1E5581B41E637007A6182 /* Carthage */,
 			);
 			buildRules = (
 			);
@@ -247,22 +246,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		9DF1E5581B41E637007A6182 /* Carthage */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/iOS/ReactiveCocoa.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/Result.framework",
-			);
-			name = Carthage;
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
-		};
 		9DF1E5591B41E667007A6182 /* Carthage */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -411,7 +394,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -435,7 +417,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",

--- a/ReactiveArray/Operation.swift
+++ b/ReactiveArray/Operation.swift
@@ -84,7 +84,7 @@ public func !=<T: Equatable>(lhs: Operation<T>, rhs: Operation<T>) -> Bool {
 // that when T is equatable it can compare an array of operations.
 public func ==<T: Equatable>(lhs: [Operation<T>], rhs: [Operation<T>]) -> Bool {
     let areEqual: () -> Bool = {
-        for var i = 0; i < lhs.count; i++ {
+        for i in lhs.indices {
             if lhs[i] != rhs[i] {
                 return false
             }

--- a/ReactiveArray/ReactiveArray.swift
+++ b/ReactiveArray/ReactiveArray.swift
@@ -153,3 +153,18 @@ public final class ReactiveArray<T>: CollectionType, MutableCollectionType, Cust
     }
     
 }
+
+extension ReactiveArray: ArrayLiteralConvertible {
+
+    public convenience init(arrayLiteral elements: T...) {
+        self.init(elements: elements)
+    }
+
+}
+
+extension ReactiveArray: Equatable {}
+
+public func == <T>(lhs: ReactiveArray<T>, rhs: ReactiveArray<T>) -> Bool {
+    return lhs === rhs
+}
+

--- a/ReactiveArrayTests/ReactiveArraySpec.swift
+++ b/ReactiveArrayTests/ReactiveArraySpec.swift
@@ -10,6 +10,7 @@ import Quick
 import Nimble
 import ReactiveArray
 import ReactiveCocoa
+import Result
 
 private func waitForOperation<T>(fromProducer producer: SignalProducer<Operation<T>, NoError>,
     when: () -> (),


### PR DESCRIPTION
Hi. I found your code very useful, and added a fun ReactiveArray UI example in https://github.com/inamiy/ReactiveCocoaCatalog/pull/4 you might be interested :wink: 

There were some fixes & improvements needed for integration as follows:
- ReactiveCocoa 4.1.0 & Result 2.0.0 for Swift 2.2 support
- Remove unnecessary `carthage copy-frameworks` (this is only for app binary)
- Change `ENABLE_BITCODE = Default (YES)`
- Conform ReactiveArray to ArrayLiteralConvertible & Equatable

Sorry for bulk fixes, but I think they are all needed, so hopefully you will merge this!
